### PR TITLE
Add example config how to configure puppeteer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@
 Write UI tests using [Cucumber](https://github.com/cucumber/cucumber), [Gherkin](https://github.com/cucumber/cucumber/wiki/Gherkin), [Puppeteer](https://github.com/GoogleChrome/puppeteer), and [Jest](https://facebook.github.io/jest/). It uses the [React TodoMVC](http://todomvc.com/examples/react/#/) project as a test UI. The Jest integration is made possible by the awesome [jest-puppeteer](https://github.com/smooth-code/jest-puppeteer) and [jest-cucumber](https://github.com/bencompton/jest-cucumber) packages 🙌
 
 Run `yarn` to install the dependencies and then `yarn test` to execute the UI tests.
+
+To run the tests in headless mode:
+
+```
+$ HEADLESS=false yarn test
+```

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  launch: {
+    headless: process.env.HEADLESS !== 'false',
+  },
+}


### PR DESCRIPTION
This is to illustrate how to run tests not in headless mode.

Closes #4